### PR TITLE
Update Module.php

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -28,7 +28,7 @@ class Module
         }
 
         // Access-Control headers are received during OPTIONS requests
-        if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+        if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 
             if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
                 header("Access-Control-Allow-Methods: GET, POST, OPTIONS");


### PR DESCRIPTION
When having installed and enabled zf3-rest-api along with Zend-session and php is configured display notices, cli zend and doctine-module commands (e.g. doctrine-module orm:validate-schema) fail to run with the following errors:

PHP Notice:  Undefined index: REQUEST_METHOD in vendor/multidots/zf3-rest-api/src/Module.php on line 31

Notice: Undefined index: REQUEST_METHOD in vendor/multidots/zf3-rest-api/src/Module.php on line 31
PHP Warning:  ini_set(): Headers already sent. You cannot change the session module's ini settings at this time in vendor/zendframework/zend-session/src/Config/SessionConfig.php on line 148

Warning: ini_set(): Headers already sent. You cannot change the session module's ini settings at this time in vendor/zendframework/zend-session/src/Config/SessionConfig.php on line 148
PHP Fatal error:  Uncaught Zend\Session\Exception\InvalidArgumentException: 'session.cookie_lifetime' is not a valid sessions-related ini setting. in vendor/zendframework/zend-session/src/Config/SessionConfig.php:155

The proposed change checks that $_SERVER['REQUEST_METHOD'] is set before trying to access it, suppressing this way the notice messages so that no "Headers already sent" occures  in SessionConfig.php.